### PR TITLE
Extract test bugfix from Hafiz's PR

### DIFF
--- a/UnitTests/TestSubscription.cs
+++ b/UnitTests/TestSubscription.cs
@@ -58,7 +58,7 @@ namespace UnitTests
         </PublishData>";
 
             string path = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            string filename = "/SubscriptionAttempt.xml";
+            string filename = "SubscriptionAttempt.xml";
             string filepath = Path.Combine(path, filename);
 
             System.IO.File.WriteAllText(filepath, content, System.Text.Encoding.UTF8);


### PR DESCRIPTION
Including the slash puts the file into the root directory which is inappropriate and may result in permissions issues.
